### PR TITLE
py2-3 compatibility bugfix

### DIFF
--- a/para/pbs.py
+++ b/para/pbs.py
@@ -13,6 +13,13 @@ import time
 import os
 import subprocess
 
+# For python 2->3 compatibility:
+try:
+    # Only exists in py3: 
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = OSError
+
 __all__ = ['qsub']
 
 PBS_MPI = \


### PR DESCRIPTION
In `para/pbs.py` you do some exception handling if the `qsub` call fails. Python 3 raises `FileNotFoundError`, but this error doesn't exist in python 2. I've made a quick monkey patch to replace `FileNotFoundError` with `OSError` if `FileNotFoundError` is not available. This works on python 2 and doesn't change the behavior for python 3.
